### PR TITLE
Eulogy snowfall fedora php7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Welcome to the Sentora Installation Script Git repository, this provides a centr
 Our installation script currently support the following operating systems/distributions:
 
 * CentOS 6 and 7
-* Ubuntu 12.04 and 14.04
+* Ubuntu 14.04 ans 16.04
 * Debian 7 and 8
+* Fedora 24 and 25
   
 Preliminary install information can be found here: [Sentora Documentation](http://docs.sentora.org/index.php?node=7)
  

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -19,7 +19,7 @@
 # Supported Operating Systems: 
 # CentOS 6.*/7.* Minimal, 
 # Fedora 24/25 Minimal,
-# Ubuntu server 12.04/14.04/16.04
+# Ubuntu server 12.04/14.04
 # Debian 7.*/8.* 
 # 32bit and 64bit
 #
@@ -155,10 +155,15 @@ elif [[ "$OS" = "Ubuntu" || "$OS" = "debian" ]]; then
        dpkg -l "$1" 2> /dev/null | grep '^ii' &> /dev/null
     }
     
-    DB_PCKG="mysql-server"
     HTTP_PCKG="apache2"
-    PHP_PCKG="apache2-mod-php5"
     BIND_PCKG="bind9"
+	if [[ "$VER" != "16.04" ]]; then
+		PHP_PCKG="apache2-mod-php5"
+		DB_PCKG="mysql-server"
+	else
+		PHP_PCKG="apache2-mod-php"
+		DB_PCKG="mysql-server"
+	fi
 fi
 
 # Note : Postfix is installed by default on centos netinstall / minimum install.
@@ -629,6 +634,9 @@ elif [[ "$OS" = "Fedora" ]]; then
 	$PACKAGE_INSTALLER php-pecl-zip.x86_64 openssl mod_ssl php-pecl-apcu.x86_64 git # Those are optionals, but very usefull for web hosting / owncloud and SSL setup	
 elif [[ "$OS" = "Ubuntu" || "$OS" = "debian" ]]; then
     $PACKAGE_INSTALLER sudo vim make zip unzip debconf-utils at build-essential bash-completion ca-certificates e2fslibs
+	if  [[ "$OS" = "debian" ]]; then
+		$PACKAGE_INSTALLER gawk
+	fi
 fi
 
 #--- Download Sentora archive from GitHub
@@ -935,7 +943,7 @@ if [[ "$OS" = "CentOs" || "$OS" = "Fedora" ]]; then
 		$PACKAGE_INSTALLER postfix-mysql
 	fi
     USR_LIB_PATH="/usr/libexec"
-elif [[ "$OS" = "Ubuntu" ]]; then
+elif [[ "$OS" = "Ubuntu" || "$OS" = "debian" ]]; then
     $PACKAGE_INSTALLER postfix postfix-mysql
     USR_LIB_PATH="/usr/lib"
 fi


### PR DESCRIPTION
# This is the Eulogy's installer version for Fedora and Ubuntu 16.04

## New features 

Support for 

Fedora 24 and 25
Ubuntu 16.04

## Updates

Option to updates the following apps from Sentora

phpMyAdmin 4.0.10 to 4.7.x (or last stable)
Roundcube 1.04 to 1.2.x
phpSysInfo 3.2.4 to 3.27 (last stable)

Installation choice for suhosin last version or suhosin7 for php7.x support

## Compatibility improvement

mysql 5.7+ 

- Temporary fix for database creation issue;
- Allow to use a other Superuser then root to fix the mysql 5.7+ root permission security update.

## Know issues

With php 7 only.

- Suhosin7 may not works well with some php 7 versions. To avoid the problem til it's solved, you can disable the suhosin under the Apache Admin Module for the vhost. Less secure but make it works.

- Issue already open to the suhosin7 github.

## Drop support

- Ubuntu 12.04 no longuer supported.